### PR TITLE
Move require gli from bin/hook to lib/hook.rb

### DIFF
--- a/bin/hook
+++ b/bin/hook
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require 'gli'
 require 'hook'
 
 # Main class for GLI app

--- a/lib/hook.rb
+++ b/lib/hook.rb
@@ -3,6 +3,7 @@
 require 'hook/version.rb'
 require 'shellwords'
 require 'cgi'
+require 'gli'
 require 'hook/string.rb'
 require 'hook/hookapp.rb'
 require 'hook/hooker.rb'


### PR DESCRIPTION
markdown_document_listener uses code from gli, so without this, you can't require hook as a library without having to require gli yourself.