### PR TITLE
Add results.html to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 pkg
 vendor
 *.bak
+/results.html


### PR DESCRIPTION
This file is generated by running rake features, so gitignore it to avoid it from accidentally being added.